### PR TITLE
Add a Dockerfile for cross-compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,13 +3,66 @@ name: CI
 on:
   push:
     branches: [main]
+    tags:
+      - 'v*'
   pull_request:
     branches: [main]
 
 env:
   CARGO_TERM_COLOR: always
+  REPO_SLUG: "wasmedge/runwasi"
 
 jobs:
+  hub:
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REPO_SLUG }}
+          ### frontend versioning
+          ### on semver tag:
+          # wasmedge/runwasi:1.2.3
+          # wasmedge/runwasi:1.2
+          # wasmedge/runwasi:1
+          # wasmedge/runwasi:latest
+          ### on pre-release tag:
+          # wasmedge/runwasi:1.1.0-rc.1
+          ### on push default branch (main):
+          # wasmedge/runwasi:main
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=ref,event=branch
+            type=raw,value=latest
+            type=ref,event=pr
+          bake-target: meta-helper
+          flavor: |
+            latest=false
+      - name: Login to DockerHub
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+      - name: Build and push
+        uses: docker/bake-action@v2
+        with:
+          files: |
+            ./docker-bake.hcl
+            ${{ steps.meta.outputs.bake-file }}
+          targets: image-cross
+          push: ${{ github.event_name != 'pull_request' }}
+
   build:
     runs-on: ubuntu-latest
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,56 @@
+# syntax=docker/dockerfile:1
+
+ARG RUST_VERSION=1.63
+ARG XX_VERSION=1.1.0
+
+FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx
+
+FROM --platform=$BUILDPLATFORM rust:${RUST_VERSION} AS base
+COPY --from=xx / /
+RUN apt-get update -y && apt-get install --no-install-recommends -y cmake make clang
+# Nightly is needed because there are nested workspaces
+RUN rustup default nightly
+WORKDIR /src
+
+FROM base AS build
+ARG BUILD_TAGS TARGETPLATFORM
+ENV WASMEDGE_BUILD_DIR=/src/WasmEdge/build
+ENV LD_LIBRARY_PATH=$WASMEDGE_BUILD_DIR/lib/api
+RUN xx-apt-get install -y gcc g++ libc++6-dev
+RUN rustup target add $(xx-info march)-unknown-$(xx-info os)-$(xx-info libc)
+
+COPY . .
+WORKDIR /src/WasmEdge
+
+RUN <<EOT bash
+    set -ex
+    mkdir -p build && cd build
+    cmake -DCMAKE_C_COMPILER=$(xx-info)-gcc \
+          -DCMAKE_CXX_COMPILER=$(xx-info)-g++ \
+          -DCMAKE_ASM_COMPILER=$(xx-info)-gcc \
+          -DPKG_CONFIG_EXECUTABLE="$(xx-clang --print-prog-name=pkg-config)" \
+          -DCMAKE_C_COMPILER_TARGET="$(xx-clang --print-target-triple)" \
+          -DCMAKE_CXX_COMPILER_TARGET="$(xx-clang++ --print-target-triple)" \
+          -DCMAKE_ASM_COMPILER_TARGET="$(xx-clang --print-target-triple)" \
+          -DCMAKE_SYSTEM_PROCESSOR="$(xx-info march)" \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DWASMEDGE_BUILD_AOT_RUNTIME=OFF .. && make -j
+EOT
+
+WORKDIR /src
+
+RUN --mount=type=cache,target=/usr/local/cargo/git/db \
+    --mount=type=cache,target=/usr/local/cargo/registry/cache \
+    --mount=type=cache,target=/usr/local/cargo/registry/index <<EOT
+    set -e
+    export "CARGO_TARGET_$(xx-info march | tr '[:lower:]' '[:upper:]' | tr - _)_UNKNOWN_$(xx-info os | tr '[:lower:]' '[:upper:]' | tr - _)_$(xx-info libc | tr '[:lower:]' '[:upper:]' | tr - _)_LINKER=$(xx-info)-gcc"
+    export "CC_$(xx-info march | tr '[:lower:]' '[:upper:]' | tr - _)_UNKNOWN_$(xx-info os | tr '[:lower:]' '[:upper:]' | tr - _)_$(xx-info libc | tr '[:lower:]' '[:upper:]' | tr - _)=$(xx-info)-gcc"
+    cargo build --release --target=$(xx-info march)-unknown-$(xx-info os)-$(xx-info libc)
+    cp /src/target/$(xx-info march)-unknown-$(xx-info os)-$(xx-info libc)/release/containerd-shim-wasmedge-v1 /containerd-shim-wasmedge-v1 
+EOT
+
+FROM scratch AS release
+COPY --link --from=build /containerd-shim-wasmedge-v1 /containerd-shim-wasmedge-v1 
+COPY --link --from=build /src/WasmEdge/build/lib/api/libwasmedge.so.0.0.0 /libwasmedge.so.0.0.0
+
+FROM release

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,19 @@
+# special target: https://github.com/docker/metadata-action#bake-definition
+target "meta-helper" {}
+
+group "default" {
+    targets = ["image"]
+}
+
+target "image" {
+    inherits = ["meta-helper"]
+    output = ["type=image"]
+}
+
+target "image-cross" {
+    inherits = ["image"]
+    platforms = [
+        "linux/amd64",
+        "linux/arm64"
+    ]
+}


### PR DESCRIPTION
With this Dockerfile `docker buildx bake image-cross --push --set '*.tags=rumpl/runwasi'` will create a multi-arch image containing containerd-shim-wasmedge-v1 and libwasmedge.so.0.0.0 for linux/amd64 and linux/arm64.

You can use undock (https://crazymax.dev/undock/) to download and extract the binaries:

    undock --all rumpl/runwasi

This will extract all the binaries:

    $ ls -lR
    total 0
    drwx------  4 rumpl  wheel  128 Sep 21 23:17 linux_amd64
    drwx------  4 rumpl  wheel  128 Sep 21 23:17 linux_arm64

    ./linux_amd64:
    total 18856
    -rwxr-xr-x  1 rumpl  wheel  7952216 Sep 21 23:17 containerd-shim-wasmedge-v1
    -rwxr-xr-x  1 rumpl  wheel  1699640 Sep 21 23:17 libwasmedge.so.0.0.0

    ./linux_arm64:
    total 18872
    -rwxr-xr-x  1 rumpl  wheel  8209032 Sep 21 23:17 containerd-shim-wasmedge-v1
    -rwxr-xr-x  1 rumpl  wheel  1447240 Sep 21 23:17 libwasmedge.so.0.0.0

This also adds a github actions build that will build and push the image every time a commit is made on "main".

Signed-off-by: Djordje Lukic <djordje.lukic@docker.com>