### PR TITLE
update wasmedge-* dependency uses crates.io release instead.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,9 @@ containerd-shim = "0.3.0"
 containerd-shim-wasm = { path = "crates/containerd-shim-wasm" }
 log = "0.4"
 ttrpc = "0.6"
-# wasmedge-sys = "0.9.0"
-# wasmedge-sdk = "0.4.0"
-# wasmedge-types = "0.2.1"
-wasmedge-sys = { git = "https://github.com/WasmEdge/WasmEdge.git" }
-wasmedge-sdk = { git = "https://github.com/WasmEdge/WasmEdge.git" }
-wasmedge-types = { git = "https://github.com/WasmEdge/WasmEdge.git" }
+wasmedge-sys = "0.10.0"
+wasmedge-sdk = "0.5.0"
+wasmedge-types = "0.3.0"
 chrono = "0.4.19"
 anyhow = "1.0"
 cap-std = "0.24.1"


### PR DESCRIPTION
as title