### PR TITLE
fix kill task is not working issue in special case

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -68,8 +68,7 @@ jobs:
     - name: Test hyper server
       run: |
         curl http://localhost:8080/echo -X POST -d "WasmEdge"
-        ps aux | grep -i containerd-shim-wasm | grep -v grep | awk {'print $2'} | xargs sudo kill -9
-        # sudo ctr task kill -s SIGKILL testserver
+        sudo ctr task kill -s SIGKILL testserver
 
     - name: Run reqwest demo conatiner
       run: |
@@ -92,5 +91,4 @@ jobs:
         curl http://localhost:8080/orders
         curl http://localhost:8080/update_order -X POST -d @demo/microservice-rust-mysql/update_order.json
         curl http://localhost:8080/delete_order?id=2
-        ps aux | grep -i containerd-shim-wasm | grep -v grep | awk {'print $2'} | xargs sudo kill -9
-        # sudo ctr task kill -s SIGKILL testmicroservice
+        sudo ctr task kill -s SIGKILL testmicroservice

--- a/demo/README.md
+++ b/demo/README.md
@@ -2,14 +2,6 @@
 
 All below demo cases should be run after all shim components already installed that mentioned in [README.md](../README.md#examples). 
 
-**Known Issue**
-
-Currently some demo cases run with tokio couldn't be killed by `sudo ctr task kill -s SIGKILL <container name>`. User could exit by kill shim process directly instead. For example: 
-```terminal
-$ ps aux | grep -i containerd-shim-wasm | grep -v grep | awk {'print $2'} | xargs sudo kill -9
-```
-
-
 ## Build and load all demo images first
 
 - Run
@@ -94,6 +86,11 @@ $ curl http://127.0.0.1:8080/echo -X POST -d "WasmEdge"
 - Output
 ```terminal
 WasmEdge%
+```
+
+- Kill the running task in container
+```terminal
+$ sudo ctr task kill -s SIGKILL testserver
 ```
 
 ## [Demo 2. Reqwest](https://github.com/WasmEdge/wasmedge_reqwest_demo)
@@ -424,4 +421,9 @@ $ curl http://localhost:8080/delete_order?id=2
 - Output
 ```terminal
 {"status":true}%
+```
+
+- Kill the running task in container
+```terminal
+$ sudo ctr task kill -s SIGKILL testmicroservice
 ```


### PR DESCRIPTION
Scenario:
The main thread running into an async or sleep execution context causes thread stuck for handle any wasmedge C API.

Solution:
After doing some research, I think there is no way terminate running thread directly in Rust. Instead of cancel the running task inside wasmedge, I notify control layer exit code without truly gets engine response then we could kill the task along with process exit.