### PR TITLE
Revert bin name changed before

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -50,7 +50,7 @@ jobs:
       run: |
         rustup default nightly
         make build FEATURES=wasmedge
-        sudo make install
+        sudo make install RUNTIME=wasmedge
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
@@ -62,12 +62,12 @@ jobs:
 
     - name: Run basic test case
       run: |
-        sudo ctr run --rm --runtime=io.containerd.wasmwasi.v1 docker.io/library/wasmtest:latest testwasm /wasm echo 'hello'
+        sudo ctr run --rm --runtime=io.containerd.wasmedge.v1 docker.io/library/wasmtest:latest testwasm /wasm echo 'hello'
 
     - name: Run hype demo conatiner
       run: |
-        sudo ctr run --rm --net-host --runtime=io.containerd.wasmwasi.v1 docker.io/library/hyper-demo:latest testclient /client.wasm
-        nohup sudo ctr run --rm --net-host --runtime=io.containerd.wasmwasi.v1 docker.io/library/hyper-demo:latest testserver /server.wasm &
+        sudo ctr run --rm --net-host --runtime=io.containerd.wasmedge.v1 docker.io/library/hyper-demo:latest testclient /client.wasm
+        nohup sudo ctr run --rm --net-host --runtime=io.containerd.wasmedge.v1 docker.io/library/hyper-demo:latest testserver /server.wasm &
 
     - name: Test hyper server
       run: |
@@ -76,17 +76,17 @@ jobs:
 
     - name: Run reqwest demo conatiner
       run: |
-        sudo ctr run --rm --net-host --runtime=io.containerd.wasmwasi.v1 docker.io/library/reqwest-demo:latest testreqwest
+        sudo ctr run --rm --net-host --runtime=io.containerd.wasmedge.v1 docker.io/library/reqwest-demo:latest testreqwest
 
     - name: Run db demo conatiner
       run: |
-        sudo ctr run --rm --net-host --env DATABASE_URL=mysql://root:root@127.0.0.1:3306/mysql --runtime=io.containerd.wasmwasi.v1 docker.io/library/db-demo:latest testdb /insert.wasm
-        sudo ctr run --rm --net-host --env DATABASE_URL=mysql://root:root@127.0.0.1:3306/mysql --runtime=io.containerd.wasmwasi.v1 docker.io/library/db-demo:latest testdb /query.wasm
-        sudo ctr run --rm --net-host --env DATABASE_URL=mysql://root:root@127.0.0.1:3306/mysql --runtime=io.containerd.wasmwasi.v1 docker.io/library/db-demo:latest testdb /crud.wasm
+        sudo ctr run --rm --net-host --env DATABASE_URL=mysql://root:root@127.0.0.1:3306/mysql --runtime=io.containerd.wasmedge.v1 docker.io/library/db-demo:latest testdb /insert.wasm
+        sudo ctr run --rm --net-host --env DATABASE_URL=mysql://root:root@127.0.0.1:3306/mysql --runtime=io.containerd.wasmedge.v1 docker.io/library/db-demo:latest testdb /query.wasm
+        sudo ctr run --rm --net-host --env DATABASE_URL=mysql://root:root@127.0.0.1:3306/mysql --runtime=io.containerd.wasmedge.v1 docker.io/library/db-demo:latest testdb /crud.wasm
 
     - name: Run microservice with database demo conatiner
       run: |
-        nohup sudo ctr run --rm --net-host --env DATABASE_URL=mysql://root:root@127.0.0.1:3306/mysql --runtime=io.containerd.wasmwasi.v1 docker.io/library/microservice-db-demo:latest testmicroservice &
+        nohup sudo ctr run --rm --net-host --env DATABASE_URL=mysql://root:root@127.0.0.1:3306/mysql --runtime=io.containerd.wasmedge.v1 docker.io/library/microservice-db-demo:latest testmicroservice &
 
     - name: Test microservice
       run: |
@@ -107,7 +107,7 @@ jobs:
     - name: Build and install conatiner wasmedge shim with support wasi-nn plugin
       run: |
         make build FEATURES=wasmedge,wasi_nn
-        sudo make install
+        sudo make install RUNTIME=wasmedge
 
     - name: Add WASMEDGE_PLUGIN_PATH into service containerd
       shell: 'script -q -e -c "bash {0}"'
@@ -123,7 +123,7 @@ jobs:
         wget --no-clobber https://github.com/bytecodealliance/wasi-nn/raw/main/rust/examples/images/1.jpg -O demo/wasinn/pytorch-mobilenet-image/input.jpg
         sudo ctr run --rm \
           --mount type=bind,src=$PWD/demo/wasinn/pytorch-mobilenet-image,dst=/resource,options=rbind:ro \
-          --runtime=io.containerd.wasmwasi.v1 \
+          --runtime=io.containerd.wasmedge.v1 \
           docker.io/library/wasinn-demo:latest \
           testwasinn \
           /wasm /resource/mobilenet.pt /resource/input.jpg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
       - name: package assets
         run: |
           mkdir _dist
-          cp target/release/containerd-shim-wasmwasi-v1 _dist/containerd-shim-wasmedge-v1
+          cp target/release/containerd-shim-wasmedge-v1 _dist/containerd-shim-wasmedge-v1
           cd _dist
           tar czf containerd-shim-wasmedge-v1-${{ env.RUNNER_OS }}-${{ matrix.arch }}.tar.gz containerd-shim-wasmedge-v1
       - name: upload binary as GitHub artifact

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,16 +32,19 @@ wasi_nn = ["wasmedge-sys/wasi_nn", "wasmedge-sdk/wasi_nn"]
 members = ["crates/containerd-shim-wasm"]
 
 [[bin]]
-name = "containerd-shim-wasmwasi-v1"
+name = "containerd-shim-wasmedge-v1"
 path = "src/bin/containerd-shim-wasmwasi-v1/main.rs"
+required-features = ["wasmedge"]
 
 [[bin]]
-name = "containerd-shim-wasmwasid-v1"
+name = "containerd-shim-wasmedged-v1"
 path = "src/bin/containerd-shim-wasmwasid-v1/main.rs"
+required-features = ["wasmedge"]
 
 [[bin]]
-name = "containerd-wasmwasid"
+name = "containerd-wasmedged"
 path = "src/bin/containerd-wasmwasid/main.rs"
+required-features = ["wasmedge"]
 
 [profile.release]
 panic = "abort"

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/git/db \
     export "CARGO_TARGET_$(xx-info march | tr '[:lower:]' '[:upper:]' | tr - _)_UNKNOWN_$(xx-info os | tr '[:lower:]' '[:upper:]' | tr - _)_$(xx-info libc | tr '[:lower:]' '[:upper:]' | tr - _)_LINKER=$(xx-info)-gcc"
     export "CC_$(xx-info march | tr '[:lower:]' '[:upper:]' | tr - _)_UNKNOWN_$(xx-info os | tr '[:lower:]' '[:upper:]' | tr - _)_$(xx-info libc | tr '[:lower:]' '[:upper:]' | tr - _)=$(xx-info)-gcc"
     cargo build --release --features wasmedge --target=$(xx-info march)-unknown-$(xx-info os)-$(xx-info libc)
-    cp target/$(xx-info march)-unknown-$(xx-info os)-$(xx-info libc)/release/containerd-shim-wasmwasi-v1 /containerd-shim-wasmedge-v1
+    cp target/$(xx-info march)-unknown-$(xx-info os)-$(xx-info libc)/release/containerd-shim-wasmedge-v1 /containerd-shim-wasmedge-v1
 EOT
 
 FROM scratch AS release

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,11 @@ ifneq ($(FEATURES),)
 FEATURES_FLAG = --features $(FEATURES)
 endif
 
+RUNTIME :=
+ifneq ($(RUNTIME),)
+RUNTIME = $(shell echo ${FEATURES} | grep -o "wasmedge")
+endif
+
 .PHONY: build
 build:
 	cargo build $(RELEASE_FLAG) $(FEATURES_FLAG)
@@ -38,9 +43,9 @@ clean:
 
 .PHONY: install
 install:
-	$(INSTALL) target/$(TARGET)/containerd-shim-wasmwasi-v1 $(PREFIX)/bin
-	$(INSTALL) target/$(TARGET)/containerd-shim-wasmwasid-v1 $(PREFIX)/bin
-	$(INSTALL) target/$(TARGET)/containerd-wasmwasid $(PREFIX)/bin
+	$(INSTALL) target/$(TARGET)/containerd-shim-$(RUNTIME)-v1 $(PREFIX)/bin
+	$(INSTALL) target/$(TARGET)/containerd-shim-$(RUNTIME)d-v1 $(PREFIX)/bin
+	$(INSTALL) target/$(TARGET)/containerd-$(RUNTIME)d $(PREFIX)/bin
 
 # TODO: build this manually instead of requiring buildx
 test/out/img.tar: test/image/Dockerfile test/image/src/main.rs test/image/Cargo.toml test/image/Cargo.lock

--- a/README.md
+++ b/README.md
@@ -99,22 +99,22 @@ Shared mode requires precise control over real threads and as such should not be
 
 #### Components
 
-- **containerd-shim-wasmwasi-v1**
+- **containerd-shim-wasmedge-v1**
 
 This is a containerd shim which runs wasm workloads in [WasmEdge](https://github.com/WasmEdge/WasmEdge).
-You can use it with containerd's `ctr` by specifying `--runtime=io.containerd.wasmwasi.v1` when creating the container.
-And make sure the shim binary must be in $PATH (that is the $PATH that containerd sees). Usually you just run `make install` after `make build FEATURES=wasmedge`.
+You can use it with containerd's `ctr` by specifying `--runtime=io.containerd.wasmedge.v1` when creating the container.
+And make sure the shim binary must be in $PATH (that is the $PATH that containerd sees). Usually you just run `make install RUNTIME=wasmedge` after `make build FEATURES=wasmedge`.
 
 This shim runs one per pod.
 
-- **containerd-shim-wasmwasid-v1**
+- **containerd-shim-wasmedged-v1**
 
-A cli used to connect containerd to the `containerd-wasmwasid` sandbox daemon.
-When containerd requests for a container to be created, it fires up this shim binary which will connect to the `containerd-wasmwasid` service running on the host.
+A cli used to connect containerd to the `containerd-wasmedged` sandbox daemon.
+When containerd requests for a container to be created, it fires up this shim binary which will connect to the `containerd-wasmedged` service running on the host.
 The service will return a path to a unix socket which this shim binary will write back to containerd which containerd will use to connect to for shim requests.
-This binary does not serve requests, it is only responsible for sending requests to the `contianerd-wasmwasid` daemon to create or destroy sandboxes.
+This binary does not serve requests, it is only responsible for sending requests to the `contianerd-wasmedged` daemon to create or destroy sandboxes.
 
-- **containerd-wasmwasid**
+- **containerd-wasmedged**
 
 This is a sandbox manager that enables running 1 wasm host for the entire node instead of one per pod (or container).
 When a container is created, a request is sent to this service to create a sandbox.
@@ -122,8 +122,8 @@ The "sandbox" is a containerd task service that runs in a new thread on its own 
 
 The Wasmedge engine is shared between all sandboxes in the service.
 
-To use this shim, specify `io.containerd.wasmwasid.v1` as the runtime to use.
-You will need to make sure the containerd-wasmwasid daemon has already been started.
+To use this shim, specify `io.containerd.wasmedged.v1` as the runtime to use.
+You will need to make sure the containerd-wasmedged daemon has already been started.
 
 #### Test and demo with containerd
 
@@ -158,9 +158,9 @@ test instance::wasitest::test_wasi ... ok
 
 ```terminal
 $ make build FEATURES=wasmedge 
-$ sudo make install
+$ sudo make install RUNTIME=wasmedge
 ```
-> FEATURES here support wasmedge only
+> FEATURES and RUNTIME here support wasmedge only (wasi_nn optional)
 
 - **Demo**
 
@@ -168,7 +168,7 @@ Now you can use the test image provided in this repo to have test with, use `mak
 
 - Case 1.
 
-Run it with `sudo ctr run --rm --runtime=io.containerd.wasmwasi.v1 docker.io/library/wasmtest:latest testwasm /wasm echo 'hello'`. You should see some output repeated like:
+Run it with `sudo ctr run --rm --runtime=io.containerd.wasmedge.v1 docker.io/library/wasmtest:latest testwasm /wasm echo 'hello'`. You should see some output repeated like:
 ```terminal
 hello
 exiting
@@ -176,7 +176,7 @@ exiting
 
 - Case 2.
 
-Run it with `sudo ctr run --rm --runtime=io.containerd.wasmwasi.v1 docker.io/library/wasmtest:latest testwasm`.
+Run it with `sudo ctr run --rm --runtime=io.containerd.wasmedge.v1 docker.io/library/wasmtest:latest testwasm`.
 You should see some output repeated like:
 
 ```terminal

--- a/demo/README.md
+++ b/demo/README.md
@@ -22,7 +22,7 @@ $ make load_demo
 
 - Run
 ```terminal
-$ sudo ctr run --rm --net-host --runtime=io.containerd.wasmwasi.v1 docker.io/library/hyper-demo:latest testclient /client.wasm
+$ sudo ctr run --rm --net-host --runtime=io.containerd.wasmedge.v1 docker.io/library/hyper-demo:latest testclient /client.wasm
 ```
 
 - Output
@@ -77,7 +77,7 @@ with a POST body: hello wasmedge
 
 - Run
 ```terminal
-$ sudo ctr run --rm --net-host --runtime=io.containerd.wasmwasi.v1 docker.io/library/hyper-demo:latest testserver /server.wasm
+$ sudo ctr run --rm --net-host --runtime=io.containerd.wasmedge.v1 docker.io/library/hyper-demo:latest testserver /server.wasm
 ```
 
 - Output
@@ -104,7 +104,7 @@ $ sudo ctr task kill -s SIGKILL testserver
 
 - Run
 ```terminal
-$ sudo ctr run --rm --net-host --runtime=io.containerd.wasmwasi.v1 docker.io/library/reqwest-demo:latest testreqwest
+$ sudo ctr run --rm --net-host --runtime=io.containerd.wasmedge.v1 docker.io/library/reqwest-demo:latest testreqwest
 ```
 
 - Output
@@ -177,7 +177,7 @@ You need start mysql service first. Here assume user/password is root/123.
 
 - Run - insert
 ```terminal
-$ sudo ctr run --rm --net-host --env DATABASE_URL=mysql://root:123@127.0.0.1:3306/mysql --runtime=io.containerd.wasmwasi.v1 docker.io/library/db-demo:latest testdb /insert.wasm
+$ sudo ctr run --rm --net-host --env DATABASE_URL=mysql://root:123@127.0.0.1:3306/mysql --runtime=io.containerd.wasmedge.v1 docker.io/library/db-demo:latest testdb /insert.wasm
 ```
 
 - Output
@@ -218,7 +218,7 @@ Yay!
 
 - Run - query
 ```terminal
-$ sudo ctr run --rm --net-host --env DATABASE_URL=mysql://root:123@127.0.0.1:3306/mysql --runtime=io.containerd.wasmwasi.v1 docker.io/library/db-demo:latest testdb /query.wasm
+$ sudo ctr run --rm --net-host --env DATABASE_URL=mysql://root:123@127.0.0.1:3306/mysql --runtime=io.containerd.wasmedge.v1 docker.io/library/db-demo:latest testdb /query.wasm
 ```
 
 - Output
@@ -239,7 +239,7 @@ $ sudo ctr run --rm --net-host --env DATABASE_URL=mysql://root:123@127.0.0.1:330
 
 - Run - CRUD
 ```terminal
-$ sudo ctr run --rm --net-host --env DATABASE_URL=mysql://root:123@127.0.0.1:3306/mysql --runtime=io.containerd.wasmwasi.v1 docker.io/library/db-demo:latest testdb /crud.wasm
+$ sudo ctr run --rm --net-host --env DATABASE_URL=mysql://root:123@127.0.0.1:3306/mysql --runtime=io.containerd.wasmedge.v1 docker.io/library/db-demo:latest testdb /crud.wasm
 ```
 
 - Output
@@ -377,7 +377,7 @@ create new table
 
 - Run
 ```terminal
-$ sudo ctr run --rm --net-host --env DATABASE_URL=mysql://root:123@127.0.0.1:3306/mysql --runtime=io.containerd.wasmwasi.v1 docker.io/library/microservice-db-demo:latest testmicroservice
+$ sudo ctr run --rm --net-host --env DATABASE_URL=mysql://root:123@127.0.0.1:3306/mysql --runtime=io.containerd.wasmedge.v1 docker.io/library/microservice-db-demo:latest testmicroservice
 ```
 
 - Open second session and run
@@ -459,7 +459,7 @@ Environment="WASMEDGE_PLUGIN_PATH=<Your Plugin Install Path>"
 - Build and install wasmedge shim with support wasi-nn plugin
 ```terminal
 $ make build FEATURES=wasmedge,wasi_nn
-$ sudo make install
+$ sudo make install RUNTIME=wasmedge
 ```
 
 - Download test image
@@ -473,7 +473,7 @@ Congratulations!! We done.
 
 - Run
 ```terminal
-sudo ctr run --rm --mount type=bind,src=$(pwd)/demo/wasinn/pytorch-mobilenet-image,dst=/resource,options=rbind:ro --runtime=io.containerd.wasmwasi.v1 docker.io/library/wasinn-demo:latest testwasinn /wasm /resource/mobilenet.pt /resource/input.jpg
+sudo ctr run --rm --mount type=bind,src=$(pwd)/demo/wasinn/pytorch-mobilenet-image,dst=/resource,options=rbind:ro --runtime=io.containerd.wasmedge.v1 docker.io/library/wasinn-demo:latest testwasinn /wasm /resource/mobilenet.pt /resource/input.jpg
 ```
 
 - Output

--- a/docs/windows-getting-started.md
+++ b/docs/windows-getting-started.md
@@ -14,7 +14,7 @@ To finish off installing pre-requisites, install Rust following [this](https://w
 
 After following these steps and navigating to the runwasi directory in your terminal:
 - run `make build FEATURES=wasmedge`,
-- run `make install`,
+- run `make install RUNTIME=wasmedge`,
 - run `make test/out/img.tar`,
 - open a secondary terminal and run `containerd`, and
 - run `make load`.

--- a/src/bin/containerd-shim-wasmwasi-v1/main.rs
+++ b/src/bin/containerd-shim-wasmwasi-v1/main.rs
@@ -5,7 +5,7 @@ use runwasi::runtime_utils::runtime_check;
 use runwasi::wasmedge::instance::Wasi as WasiInstance;
 
 fn main() {
-    #[cfg(feature = "wasmedge")]
-    shim::run::<ShimCli<WasiInstance, wasmedge_sdk::Vm>>("io.containerd.wasmwasi.v1", None);
     runtime_check();
+    #[cfg(feature = "wasmedge")]
+    shim::run::<ShimCli<WasiInstance, wasmedge_sdk::Vm>>("io.containerd.wasmedge.v1", None);
 }

--- a/src/bin/containerd-shim-wasmwasid-v1/main.rs
+++ b/src/bin/containerd-shim-wasmwasid-v1/main.rs
@@ -2,5 +2,5 @@ use containerd_shim as shim;
 use containerd_shim_wasm::sandbox::manager::Shim;
 
 fn main() {
-    shim::run::<Shim>("containerd-shim-wasmwasid-v1", None)
+    shim::run::<Shim>("containerd-shim-wasmedged-v1", None)
 }

--- a/src/bin/containerd-wasmwasid/main.rs
+++ b/src/bin/containerd-wasmwasid/main.rs
@@ -11,6 +11,7 @@ use ttrpc::{self, Server};
 
 fn main() {
     info!("starting up!");
+    runtime_check();
     let s: ManagerService<_, Local<WasiInstance, _>> =
         ManagerService::new(WasiInstance::new_engine().unwrap());
     let s = Arc::new(Box::new(s) as Box<dyn Manager + Send + Sync>);


### PR DESCRIPTION
1. Use features to split the different binary names and update all docs and CI
2. Add RUNTIME variable for identify which shim binaries should be installed

Signed-off-by: vincent <vincent@secondstate.io>