### PR TITLE
Update github workflow image to bypass apt install fail issue

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   run-all-examples:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
 


### PR DESCRIPTION
It seems that there might be an issue with the GitHub runner image.